### PR TITLE
Add order attribute to items and technologies. Fixes #22

### DIFF
--- a/prototypes/item.lua
+++ b/prototypes/item.lua
@@ -5,6 +5,7 @@ data:extend({
         icon = "__ShuttleTrain__/graphics/icon_shuttleTrain.png",
         flags = {"goes-to-quickbar"},
         subgroup = "transport",
+        order = "a[train-system]-f[shuttle-train]",
         place_result = "shuttleTrain",
         stack_size = 5,
     }

--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -21,6 +21,7 @@ data:extend({
             {"science-pack-2", 1},
           },
           time = 20
-        }
+        },
+        order = "c-g-b-a"
     },
 })


### PR DESCRIPTION
Fixes the item and technology order issue described in #22.

Here the new technology position:
![technologyorder](https://cloud.githubusercontent.com/assets/1579362/15634272/07573c38-25c0-11e6-94a6-da98059743fb.png)

Here the old Item position:
![olditemorder](https://cloud.githubusercontent.com/assets/1579362/15634286/629fb6ce-25c0-11e6-8002-2b2a00d70a84.png)

Here the new item position:
![newitemorder](https://cloud.githubusercontent.com/assets/1579362/15634287/6740bd54-25c0-11e6-8b9d-8526114d23a7.png)
