### PR TITLE
Quick fix to shuttle train broken by Factorio 0.13.5

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -18,7 +18,7 @@ function load()
 end
 
 script.on_init(init)
-script.on_load(load)
+script.on_configuration_changed(load)
 
 
 script.on_event(defines.events.on_tick, function(event) on_tick(event) end) -- register update function


### PR DESCRIPTION
Factorio 0.13.5 does a CRC check to the mod's lua global table before and after on_load events. Changed on_load to on_configuration_changed.
